### PR TITLE
fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module golang.org/x/lint
+module github.com/haruyama/golintx
 
 require golang.org/x/tools v0.0.0-20190311212946-11955173bddd


### PR DESCRIPTION
fix go modules install error.

```
go: github.com/haruyama/golintx@v0.0.0-20190508012218-0fccf27a3559: parsing go.mod: unexpected module path "golang.org/x/lint"
go: error loading module requirements
```